### PR TITLE
Optimize Image Size and Security: Switch to Alpine Base with Multistage Build, Update OpenSSL, and Add Security Modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,86 +1,211 @@
-FROM ubuntu:24.04
+FROM alpine:3.20 AS build
 
-LABEL maintainer="eXo Platform <docker@exoplatform.com>"
+ARG BUILD
+ARG NGX_MAINLINE_VER=1.26.2
+ARG MODSEC_VER=v3.0.13
+ARG OPENSSL_VER=openssl-3.4.0
+ARG NGX_BROTLI=master
+ARG NGX_HEADERS_MORE=v0.37
+ARG NGX_NJS=0.8.8
+ARG NGX_MODSEC=v1.0.3
+ARG NGX_GEOIP2=3.4
+ARG NGX_SECURITY_HEADERS=0.1.1
+ARG NGX_LDAP_AUTH=v1.7
+ARG NGX_UPSTREAM_JVM_ROUTE=master
 
-ENV NGINX_VERSION=1.26.2
-ENV MORE_HEADERS_VERSION=0.37
-ENV SECURITY_HEADERS_VERSION=0.1.0
-ENV BUILD_DIR=/tmp/build
+WORKDIR /src
 
-ARG DEBIAN_FRONTEND=noninteractive
+# Install the required packages
+RUN apk add --no-cache \
+    ca-certificates \
+    build-base \
+    patch \
+    cmake \
+    git \
+    libtool \
+    autoconf \
+    automake \
+    libatomic_ops-dev \
+    zlib-dev \
+    pcre2-dev \
+    linux-headers \
+    yajl-dev \
+    libxml2-dev \
+    libxslt-dev \
+    perl-dev \
+    curl-dev \
+    lmdb-dev \
+    geoip-dev \
+    libmaxminddb-dev \
+    libfuzzy2-dev \
+    gd-dev  \
+    libldap \
+    openldap-dev \
+    patch 
 
-RUN apt-get update && apt-get install -y build-essential zlib1g-dev libpcre3 libpcre3-dev uuid-dev unzip wget curl libssl-dev dnsmasq supervisor libldap2-dev git libgd-dev && \
-    rm -rf /var/lib/apt/lists/*
+RUN sed -i "s/999/99/" /etc/group
+RUN \
+    addgroup --gid 999 -S nginx \
+    && adduser --uid 999 -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx
 
-RUN mkdir ${BUILD_DIR} \
-    && cd ${BUILD_DIR} \
-    && wget https://github.com/openresty/headers-more-nginx-module/archive/v${MORE_HEADERS_VERSION}.tar.gz \
-    && tar -xzf v${MORE_HEADERS_VERSION}.tar.gz \
-    && cd ${BUILD_DIR} && git clone https://github.com/kvspb/nginx-auth-ldap.git && cd nginx-auth-ldap && git checkout 42d195d7a7575ebab1c369ad3fc5d78dc2c2669c \
-    && cd ${BUILD_DIR} && wget http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
-    && tar -xzf nginx-${NGINX_VERSION}.tar.gz
+# Clone and build OpenSSL
+RUN git clone --recursive --branch ${OPENSSL_VER} --depth 1 https://github.com/openssl/openssl /src/openssl
 
-RUN cd ${BUILD_DIR} && wget -O nginx-upstream-jvm-route.zip https://github.com/nulab/nginx-upstream-jvm-route/archive/c4c92e797c0a06840017bf5c881378dabf6490a5.zip \
-    && unzip -d nginx-upstream-jvm-route nginx-upstream-jvm-route.zip \
-    && cp nginx-upstream-jvm-route/*/* nginx-upstream-jvm-route/ \
-    && rm -rf nginx-upstream-jvm-route/nginx-upstream-jvm-route-*
+# ModSecurity
+RUN (git clone --recursive --depth 1 --branch "$MODSEC_VER" https://github.com/SpiderLabs/ModSecurity /src/ModSecurity \
+    && sed -i "s|SecRuleEngine.*|SecRuleEngine On|g" /src/ModSecurity/modsecurity.conf-recommended \
+    && sed -i "s|unicode.mapping|/etc/nginx/modsec/unicode.mapping|g" /src/ModSecurity/modsecurity.conf-recommended \
+    && cd /src/ModSecurity \
+    && /src/ModSecurity/build.sh \
+    && /src/ModSecurity/configure --with-pcre2 --with-lmdb \
+    && make -j "$(nproc)" \
+    && make -j "$(nproc)" install \
+    && strip -s /usr/local/modsecurity/lib/libmodsecurity.so.3) 
 
-RUN cd ${BUILD_DIR} && wget -O nginx-security-headers.zip https://github.com/GetPageSpeed/ngx_security_headers/archive/refs/tags/${SECURITY_HEADERS_VERSION}.zip \
-    && unzip -d . nginx-security-headers.zip
+# Modules
+RUN (git clone --recursive --depth 1 --branch "$NGX_BROTLI" https://github.com/google/ngx_brotli /src/ngx_brotli \
+    && git clone --recursive --depth 1 --branch "$NGX_HEADERS_MORE" https://github.com/openresty/headers-more-nginx-module /src/headers-more-nginx-module \
+    && git clone --recursive --depth 1 --branch "$NGX_NJS" https://github.com/nginx/njs /src/njs \
+    && git clone --recursive --depth 1 --branch "$NGX_MODSEC" https://github.com/SpiderLabs/ModSecurity-nginx /src/ModSecurity-nginx \
+    && git clone --recursive --depth 1 --branch "$NGX_GEOIP2" https://github.com/leev/ngx_http_geoip2_module /src/ngx_http_geoip2_module \
+    && git clone --recursive --depth 1 --branch "$NGX_SECURITY_HEADERS" https://github.com/GetPageSpeed/ngx_security_headers /src/ngx_security_headers \
+    && git clone --recursive --depth 1 --branch "$NGX_UPSTREAM_JVM_ROUTE" https://github.com/nulab/nginx-upstream-jvm-route /src/nginx-upstream-jvm-route \
+    && git clone --recursive --depth 1 --branch "$NGX_LDAP_AUTH" https://github.com/Ericbla/nginx-auth-ldap /src/nginx-auth-ldap )
 
-WORKDIR ${BUILD_DIR}/nginx-${NGINX_VERSION}
+# Nginx
+RUN (wget https://nginx.org/download/nginx-"$NGX_MAINLINE_VER".tar.gz -O - | tar xzC /src \
+    && mv /src/nginx-"$NGX_MAINLINE_VER" /src/nginx \
+    && wget https://raw.githubusercontent.com/nginx-modules/ngx_http_tls_dyn_size/master/nginx__dynamic_tls_records_1.25.1%2B.patch -O /src/nginx/dynamic_tls_records.patch \
+    && sed -i "s|nginx/|NGINX-OpenSSL with ModSec/|g" /src/nginx/src/core/nginx.h \
+    && sed -i "s|Server: nginx|Server: NGINX-OpenSSL with ModSec|g" /src/nginx/src/http/ngx_http_header_filter_module.c \
+    && sed -i "s|<hr><center>nginx</center>|<hr><center>NGINX-OpenSSL with ModSec</center>|g" /src/nginx/src/http/ngx_http_special_response.c \
+    && cd /src/nginx \
+    && patch -p1 < dynamic_tls_records.patch \
+    && patch -p0 < /src/nginx-upstream-jvm-route/jvm_route.patch)
 
-RUN  patch -p0 < ../nginx-upstream-jvm-route/jvm_route.patch \
-     && ./configure \
-        --prefix=/etc/nginx \
-        --sbin-path=/usr/sbin/nginx \
-        --modules-path=/usr/lib/nginx/modules \
-        --conf-path=/etc/nginx/nginx.conf \
-        --error-log-path=/var/log/nginx/error.log \
-        --http-log-path=/var/log/nginx/access.log \
-        --pid-path=/var/run/nginx.pid \
-        --lock-path=/var/run/nginx.lock \
-        --http-client-body-temp-path=/var/cache/nginx/client_temp \
-        --with-http_ssl_module \
-        --http-proxy-temp-path=/var/cache/nginx/proxy_temp \
-        --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp \
-        --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp \
-        --http-scgi-temp-path=/var/cache/nginx/scgi_temp \
-        --user=nginx --group=nginx \
-        --add-module=${BUILD_DIR}/headers-more-nginx-module-${MORE_HEADERS_VERSION} \
-        --add-module=${BUILD_DIR}/nginx-auth-ldap \
-        --add-module=${BUILD_DIR}/nginx-upstream-jvm-route \
-        --add-module=${BUILD_DIR}/ngx_security_headers-${SECURITY_HEADERS_VERSION} \
-        --with-file-aio \
-        --with-threads \
-        --with-http_addition_module \
-        --with-http_gunzip_module \
-        --with-http_gzip_static_module \
-        --with-http_auth_request_module \
-        --with-http_realip_module \
-        --with-http_v2_module \
-        --with-http_image_filter_module=dynamic  \
-        --with-stream \
-        --with-stream_ssl_module \
-        --with-http_stub_status_module \
-    && make -j 4 install \
-    && rm -rf ${BUILD_DIR}
+RUN cd /src/nginx \
+    && ./configure \
+    --build=${BUILD} \
+    --prefix=/etc/nginx \
+    --sbin-path=/usr/sbin/nginx \
+    --modules-path=/usr/lib/nginx/modules \
+    --conf-path=/etc/nginx/nginx.conf \
+    --error-log-path=/var/log/nginx/error.log \
+    --http-log-path=/var/log/nginx/access.log \
+    --pid-path=/var/run/nginx.pid \
+    --lock-path=/var/run/nginx.lock \
+    --http-client-body-temp-path=/var/cache/nginx/client_temp \
+    --http-proxy-temp-path=/var/cache/nginx/proxy_temp \
+    --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp \
+    --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp \
+    --http-scgi-temp-path=/var/cache/nginx/scgi_temp \
+    --user=nginx \
+    --group=nginx \
+    --with-compat \
+    --with-threads \
+    --with-file-aio \
+    --with-libatomic \
+    --with-pcre \
+    --without-poll_module \
+    --without-select_module \
+    --with-openssl="/src/openssl" \
+    --with-openssl-opt="no-ssl3 no-ssl3-method no-weak-ssl-ciphers" \
+    --with-mail=dynamic \
+    --with-mail_ssl_module \
+    --with-http_image_filter_module=dynamic  \
+    --with-stream=dynamic \
+    --with-stream_ssl_module \
+    --with-stream_ssl_preread_module \
+    --with-stream_realip_module \
+    --with-stream_geoip_module=dynamic \
+    --with-http_v2_module \
+    --with-http_ssl_module \
+    --with-http_perl_module=dynamic \
+    --with-http_geoip_module=dynamic \
+    --with-http_realip_module \
+    --with-http_gunzip_module \
+    --with-http_addition_module \
+    --with-http_gzip_static_module \
+    --with-http_stub_status_module \
+    --with-http_auth_request_module \
+    --add-dynamic-module=/src/ngx_brotli \
+    --add-dynamic-module=/src/headers-more-nginx-module \
+    --add-dynamic-module=/src/njs/nginx \
+    --add-dynamic-module=/src/ModSecurity-nginx \
+    --add-dynamic-module=/src/ngx_http_geoip2_module \
+    --add-module=/src/nginx-auth-ldap \
+    --add-module=/src/ngx_security_headers \
+    && make -j "$(nproc)" \
+    && make -j "$(nproc)" install \
+    && rm /src/nginx/*.patch \
+    && strip -s /usr/sbin/nginx \
+    && strip -s /usr/lib/nginx/modules/*.so
 
-RUN ln -s /usr/lib/nginx/modules /etc/nginx/modules
+FROM python:alpine3.20
 
-WORKDIR /
+COPY --from=build /etc/nginx /etc/nginx
+COPY --from=build /usr/sbin/nginx   /usr/sbin/nginx
+COPY --from=build /usr/lib/nginx /usr/lib/nginx
+COPY --from=build /usr/local/lib/perl5  /usr/local/lib/perl5
+COPY --from=build /usr/lib/perl5/core_perl/perllocal.pod    /usr/lib/perl5/core_perl/perllocal.pod
+COPY --from=build /usr/local/modsecurity/lib/libmodsecurity.so.3    /usr/local/modsecurity/lib/libmodsecurity.so.3
 
-RUN usermod -u 2005 dnsmasq
-
-RUN mkdir -p /var/log/nginx /var/cache/nginx/ \
-    && ln -s /dev/stdout /var/log/nginx/access.log \
-    && ln -s /dev/sterr /var/log/nginx/error.log \
-    && useradd --create-home --user-group -u 999 --shell /bin/false nginx
-
-COPY nginx.conf /etc/nginx/
+COPY nginx.conf /etc/nginx/nginx.conf
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY dnsmasq.conf /etc/dnsmasq.conf
 
-EXPOSE 443 80 81
+RUN sed -i "s/999/99/" /etc/group
+RUN addgroup -g 999 -S nginx \
+    && adduser -u 999 -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx
 
-CMD ["/usr/bin/supervisord"]
+RUN apk add --no-cache \
+    ca-certificates \
+    tzdata \
+    tini \
+    zlib \
+    pcre2 \
+    lmdb \
+    libstdc++ \
+    yajl \
+    libxml2 \
+    libxslt \
+    libfuzzy2 \
+    perl \
+    libcurl \
+    geoip \
+    libmaxminddb-libs \
+    libldap \
+    gd-dev  \
+    supervisor \
+    dnsmasq \
+    curl
+
+RUN mkdir -p /var/log/nginx/ \
+    && mkdir -p /etc/nginx/modsec \
+    && touch /var/log/nginx/access.log \
+    && touch /var/log/nginx/error.log \
+    && ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log \
+    && ln -s /usr/lib/nginx/modules /etc/nginx/modules \
+    && chown --verbose nginx:nginx -R /var/log/nginx
+
+COPY --from=build /src/ModSecurity/unicode.mapping  /etc/nginx/modsec/unicode.mapping
+COPY --from=build /src/ModSecurity/modsecurity.conf-recommended /etc/nginx/modsec/modsecurity.conf.example
+
+LABEL maintainer="eXo Platform <docker@exoplatform.com>"
+
+# show env
+RUN env | sort
+
+# test the configuration
+RUN nginx -V; nginx -t
+
+EXPOSE 80 81 443
+
+STOPSIGNAL SIGTERM
+
+# prepare to switch to non-root - update file permissions
+RUN chown --verbose nginx:nginx \
+    /var/run/nginx.pid
+
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,13 +119,21 @@ RUN cd /src/nginx \
     --with-stream_realip_module \
     --with-stream_geoip_module=dynamic \
     --with-http_v2_module \
+    --with-http_v3_module \
     --with-http_ssl_module \
     --with-http_perl_module=dynamic \
     --with-http_geoip_module=dynamic \
     --with-http_realip_module \
+    --with-http_random_index_module \
+    --with-http_mp4_module \
+    --with-http_flv_module \
+    --with-http_dav_module \
     --with-http_gunzip_module \
     --with-http_addition_module \
     --with-http_gzip_static_module \
+    --with-http_sub_module \
+    --with-http_slice_module \
+    --with-http_secure_link_module \
     --with-http_stub_status_module \
     --with-http_auth_request_module \
     --add-dynamic-module=/src/ngx_brotli \

--- a/README.md
+++ b/README.md
@@ -1,23 +1,84 @@
-# eXo Nginx container
+# eXo Nginx Container
 
-The repository is a build of Nginx with Google Page Speed module activated and Nginx sticky module.
+This repository contains a custom build of Nginx with additional modules, including support for ModSecurity, Google PageSpeed, and various other enhancements. This image is designed for use in environments requiring advanced HTTP and security functionalities.
 
 ## Usage
 
-This image can be use in the same way the official [nginx image](https://hub.docker.com/_/nginx/)
+This image can be used similarly to the official [nginx image](https://hub.docker.com/_/nginx/), with additional features and modules. Configuration and management follow standard Nginx conventions.
 
-## List of activated modules :
+### Example Usage
 
-* [nginx-sticky-module-ng](https://github.com/Refinitiv/nginx-sticky-module-ng.git)
-* http_ssl_module
-* ngx_headers_more
-* http_addition_module
-* http_auth_request_module
-* http_gunzip_module
-* http_gzip_static_module
-* http_realip_module
-* http_stub_status_module
-* http_v2_module
-* [nginx-auth-ldap](https://github.com/kvspb/nginx-auth-ldap.git)
-* stream 
-* stream_ssl_module
+```bash
+docker run --name exo-nginx -v $(pwd)/nginx.conf:/etc/nginx/nginx.conf:ro -p 80:80 exoplatform/nginx
+```
+
+## List of Activated Modules
+
+The following modules are included and activated in this build:
+
+### Core Modules
+
+- `http_ssl_module`: Enables HTTPS support.
+- `http_v2_module`: Adds support for HTTP/2.
+- `http_auth_request_module`: Allows for authorization requests.
+- `http_stub_status_module`: Provides basic status information.
+- `http_realip_module`: Adjusts client IP address to a trusted upstream.
+- `http_addition_module`: Appends additional content to responses.
+- `http_gunzip_module`: Decompresses responses for clients that don't support gzip.
+- `http_gzip_static_module`: Serves pre-compressed `.gz` files.
+- `http_secure_link_module`: Secures links with tokens.
+- `http_slice_module`: Enables partial content delivery.
+- `http_flv_module`: Enables streaming of FLV files.
+- `http_mp4_module`: Enables streaming of MP4 files.
+
+### Dynamic Modules
+
+- `ngx_headers_more`: Allows modification of HTTP headers.
+- `ngx_brotli`: Provides Brotli compression.
+- `ModSecurity-nginx`: Integrates ModSecurity for enhanced security.
+- `ngx_http_geoip2_module`: Adds GeoIP2-based client location.
+- `ngx_security_headers`: Enforces security-related headers.
+- `nginx-auth-ldap`: Adds LDAP-based authentication.
+
+### Stream Modules
+
+- `stream`: Enables TCP/UDP proxying.
+- `stream_ssl_module`: Adds SSL/TLS support for streams.
+- `stream_ssl_preread_module`: Allows inspection of SSL/TLS handshakes.
+- `stream_geoip_module`: Adds GeoIP support for streams.
+
+### Additional Features
+
+- [nginx-sticky-module-ng](https://github.com/Refinitiv/nginx-sticky-module-ng): Adds session persistence.
+- [nginx-upstream-jvm-route](https://github.com/nulab/nginx-upstream-jvm-route): Balances JVM-based upstreams.
+
+## Configuration
+
+The image uses a custom `nginx.conf` file by default, which can be overridden by mounting your own configuration file:
+
+```bash
+docker run -v $(pwd)/custom-nginx.conf:/etc/nginx/nginx.conf:ro exoplatform/nginx
+```
+
+### Supervisord
+
+This image includes `supervisord` for process management. The configuration is located at `/etc/supervisor/conf.d/supervisord.conf`.
+
+### ModSecurity
+
+ModSecurity is included for advanced security. Configuration can be found at `/etc/nginx/modsec/modsecurity.conf.example`. A Unicode mapping file is also provided at `/etc/nginx/modsec/unicode.mapping`.
+
+
+## Exposed Ports
+
+- `80`: HTTP
+- `81`: Additional HTTP (if required by configuration)
+- `443`: HTTPS
+
+## Maintainer
+
+Maintained by eXo Platform – [docker@exoplatform.com](mailto\:docker@exoplatform.com).
+
+---
+
+For further details, refer to the [Nginx documentation](https://nginx.org/en/docs/) and the linked module repositories.


### PR DESCRIPTION
Switch the base image to Alpine and implement a multistage build to minimize the image size, while upgrading to the latest stable version of OpenSSL and incorporating additional security modules.

Reduced image size: from 602MB to 186MB with upgraded nginx modules